### PR TITLE
working solution to the issue

### DIFF
--- a/packages/flutter/lib/src/material/input_border.dart
+++ b/packages/flutter/lib/src/material/input_border.dart
@@ -417,9 +417,7 @@ class OutlineInputBorder extends InputBorder {
     );
 
     const double cornerArcSweep = math.pi / 2.0;
-    final double tlCornerArcSweep = start < scaledRRect.tlRadiusX
-      ? math.acos(1 - start / scaledRRect.tlRadiusX)
-      : math.pi / 2.0;
+    final double tlCornerArcSweep = math.acos((1 - start / scaledRRect.tlRadiusX).clamp(0.0, 1.0));
 
     final Path path = Path()
       ..addArc(tlCorner, math.pi, tlCornerArcSweep);
@@ -430,13 +428,12 @@ class OutlineInputBorder extends InputBorder {
     const double trCornerArcStart = (3 * math.pi) / 2.0;
     const double trCornerArcSweep = cornerArcSweep;
     if (start + extent < scaledRRect.width - scaledRRect.trRadiusX) {
-      path
-        ..moveTo(scaledRRect.left + start + extent, scaledRRect.top)
-        ..lineTo(scaledRRect.right - scaledRRect.trRadiusX, scaledRRect.top)
-        ..addArc(trCorner, trCornerArcStart, trCornerArcSweep);
+      path.moveTo(scaledRRect.left + start + extent, 0.0);
+      path.lineTo(scaledRRect.right - scaledRRect.trRadiusX, scaledRRect.top);
+      path.addArc(trCorner, trCornerArcStart, trCornerArcSweep);
     } else if (start + extent < scaledRRect.width) {
       final double dx = scaledRRect.width - (start + extent);
-      final double sweep = math.acos(dx / scaledRRect.trRadiusX);
+      final double sweep = math.asin((1 - dx / scaledRRect.trRadiusX).clamp(0.0, 1.0));
       path.addArc(trCorner, trCornerArcStart + sweep, trCornerArcSweep - sweep);
     }
 


### PR DESCRIPTION
Fixes gap calculations for both ltr and rtl text directions.
Needs golden tests.

| BorderRadius | `TextDirection.ltr` | `TextDirection.rtl` |
| - | - | - |
| 8.0 | ![Screenshot from 2021-11-03 14-43-59](https://user-images.githubusercontent.com/44755140/140034965-3a0309e6-a6c9-458f-8168-f18d401181b2.png) | ![Screenshot from 2021-11-03 14-44-10](https://user-images.githubusercontent.com/44755140/140034986-74c8256a-cd99-4177-ac4c-ac783cc3356b.png) |
| 32.0 | ![Screenshot from 2021-11-03 14-43-30](https://user-images.githubusercontent.com/44755140/140034853-67cf4f45-76e5-4399-b833-8e035d945e9a.png) | ![Screenshot from 2021-11-03 14-43-42](https://user-images.githubusercontent.com/44755140/140034892-929178c0-fca6-4ead-9de0-f15171eae0bd.png) |
