### PR TITLE
Fix Material library replacement fix-data keys

### DIFF
--- a/packages/flutter/lib/fix_data/fix_material/fix_material.yaml
+++ b/packages/flutter/lib/fix_data/fix_material/fix_material.yaml
@@ -30,8 +30,8 @@ transforms:
     date: 2026-05-08
     library: 'package:flutter/material.dart'
     changes:
-      - kind: 'replacedby'
-        newlibrary: 'package:material_ui/material_ui.dart'
+      - kind: 'replacedBy'
+        newLibrary: 'package:material_ui/material_ui.dart'
 
   # Changes made in https://github.com/flutter/flutter/pull/179776
   - title: 'Replaced by cupertino CupertinoPageTransitionsBuilder'


### PR DESCRIPTION
This is a small follow-up for flutter/flutter#186915.

The new library replacement transform currently uses `replacedby` / `newlibrary`. With that exact syntax, analyzer reports the deprecated `package:flutter/material.dart` import, but `dart fix --dry-run` reports `Nothing to fix!`.

Changing the keys to `replacedBy` / `newLibrary` makes `dart fix` offer and apply the Material migration.

Manual fixture coverage:

- current syntax: `dart fix --dry-run` -> `Nothing to fix!`
- patched syntax: `dart fix --dry-run` -> fixes for normal imports, `show`, `hide`, prefixed imports, and the missing `material_ui` dependency in `pubspec.yaml`

`export 'package:flutter/material.dart'` remains a separate unsupported case.
